### PR TITLE
socket-tunnel api

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,37 @@ https://ericbarch.com/post/sockettunnel/
 5. Point your domain name's root A record at your server's IP
 6. Point a wildcard (*) A record at your server's IP
 
-## Client Usage
+## Client CLI Usage
 
 1. Start your http server that you'd like to expose to the public web (in this example we'll assume it's listening on 127.0.0.1:8000)
 2. Clone this repo and cd into it
 3. `npm i`
 4. `node bin/client --server http://YOURDOMAIN.com --subdomain YOURSUBDOMAIN --hostname 127.0.0.1 --port 8000`
 5. Browse to http://YOURSUBDOMAIN.YOURDOMAIN.com to see your local service available on the public internet
+
+## Client API Usage
+
+Assuming a web server running on 127.0.0.1:8000
+
+1. Clone this repo into your project
+2. `npm i`
+3. In your project file require socket-tunnel api and run connect():
+```JavaScript
+const socketTunnel = require('./socket-tunnel/lib/api')
+
+socketTunnel.connect("http://YOURDOMAIN.com", "YOURSUBDOMAIN", "8000",)
+.then(console.log)
+.catch(console.log)
+```
+4. Browse to http://YOURSUBDOMAIN.YOURDOMAIN.com to see your local service available on the public internet
+
+
+```Javascript
+// running socketTunnel.connect() returns a promise which resolves to the requested url or catches any errors. Both return strings.
+// options:
+// your server domain name, subdomain to request, port of local server, hostname of local server (optional. defaults to 127.0.0.1)
+socketTunnel.connect(server, subdomain, port)
+```
 
 ## Credits
 

--- a/api-example.js
+++ b/api-example.js
@@ -1,0 +1,5 @@
+const socketTunnel = require('./lib/api')
+
+socketTunnel.connect("https://domain.example", "device", "2222",)
+.then(console.log)
+.catch(console.log)

--- a/lib/api.js
+++ b/lib/api.js
@@ -4,14 +4,15 @@ const client = require("../client")
 
 let api = {
     connect: (server, subdomain, port, hostname = '127.0.0.1' )=>{
-        let options = {
-            server: server,
-            subdomain: subdomain,
-            port: port,
-            hostname: hostname
-        };
         return new Promise((res, rej)=>{
-            client(options, res, rej)
+            if (!server || !subdomain || !port || !hostname) rej('0ne or more options were not provided');
+            let options = {
+                server: server,
+                subdomain: subdomain.toString(),
+                port: port.toString(),
+                hostname: hostname
+            };
+            client(options, res, rej);
         })
     }
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,19 @@
+// client api
+
+const client = require("../client")
+
+let api = {
+    connect: (server, subdomain, port, hostname = '127.0.0.1' )=>{
+        let options = {
+            server: server,
+            subdomain: subdomain,
+            port: port,
+            hostname: hostname
+        };
+        return new Promise((res, rej)=>{
+            client(options, res, rej)
+        })
+    }
+};
+
+module.exports = api;

--- a/nginx.conf.sample
+++ b/nginx.conf.sample
@@ -1,4 +1,11 @@
 # Example of nginx config for proxying requests to socket-tunnel server
+
+server {
+    listen *:80;
+    server_name subdomain.example.com *.subdomain.example.com;
+    rewrite     ^   https://$host$request_uri? permanent;
+}
+
 server {
     listen *:443;
 

--- a/server.js
+++ b/server.js
@@ -146,7 +146,7 @@ module.exports = (options) => {
       }
 
       // domains are case insensitive
-      let reqNameNormalized = requestedName.toLowerCase();
+      let reqNameNormalized = requestedName.toString().toLowerCase().replace(/[^0-9a-z-]/g,"");
 
       // make sure the client is requesting a valid subdomain
       if (reqNameNormalized.length === 0 || !isValidDomain(`${reqNameNormalized}.example.com`)) {


### PR DESCRIPTION
- Added a client api to use with node for automated creation of a socket connection to the server (autonomous IoT devices)

- Using client.js will now return an accessible url on successful registration. The client CLI will work as intended but will now by default log the url to the console.

- Updated the nginx.conf.sample to include redirects from http to https.

- There was also still an error where a domain name comprised of only numbers would crash the server. I updated the reqNameNormalized to convert any requested subdomain to a string first and only move valid characters to lower case which should fix this issue.
